### PR TITLE
Refactor, settings, colored spectrograms, UI changes

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		14D570CD2C5F4BB70011E668 /* BoringBattery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570CC2C5F4BB70011E668 /* BoringBattery.swift */; };
 		14D570D22C5F6C6A0011E668 /* BoringExtrasMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */; };
 		14D570D52C5F710B0011E668 /* constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D570D42C5F710B0011E668 /* constants.swift */; };
+		B15063522C63D41A00EBB0E3 /* Image2Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15063512C63D41A00EBB0E3 /* Image2Color.swift */; };
+		B15063542C63E18700EBB0E3 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15063532C63E18700EBB0E3 /* SettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,6 +59,8 @@
 		14D570CC2C5F4BB70011E668 /* BoringBattery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringBattery.swift; sourceTree = "<group>"; };
 		14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoringExtrasMenu.swift; sourceTree = "<group>"; };
 		14D570D42C5F710B0011E668 /* constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = constants.swift; sourceTree = "<group>"; };
+		B15063512C63D41A00EBB0E3 /* Image2Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image2Color.swift; sourceTree = "<group>"; };
+		B15063532C63E18700EBB0E3 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +95,7 @@
 				14D570CC2C5F4BB70011E668 /* BoringBattery.swift */,
 				14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */,
 				1471A8582C6281BD0058408D /* BoringNotchWindow.swift */,
+				B15063532C63E18700EBB0E3 /* SettingsView.swift */,
 			);
 			path = components;
 			sourceTree = "<group>";
@@ -130,6 +135,7 @@
 				14D570BA2C5E98E30011E668 /* enums */,
 				14D570B72C5E98960011E668 /* animations */,
 				147163B52C5D804B0068B555 /* managers */,
+				B15063502C63D3F600EBB0E3 /* extensions */,
 				1471639B2C5D362F0068B555 /* components */,
 				14CEF4152C5CAED300855D72 /* boringNotchApp.swift */,
 				14CEF4172C5CAED300855D72 /* ContentView.swift */,
@@ -179,6 +185,14 @@
 				14D570D42C5F710B0011E668 /* constants.swift */,
 			);
 			path = strings;
+			sourceTree = "<group>";
+		};
+		B15063502C63D3F600EBB0E3 /* extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B15063512C63D41A00EBB0E3 /* Image2Color.swift */,
+			);
+			path = extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -274,7 +288,9 @@
 				14D570B62C5E961A0011E668 /* NotchShape.swift in Sources */,
 				14CEF4162C5CAED300855D72 /* boringNotchApp.swift in Sources */,
 				14D570C22C5EAFBF0011E668 /* EmptyState.swift in Sources */,
+				B15063522C63D41A00EBB0E3 /* Image2Color.swift in Sources */,
 				14D570D22C5F6C6A0011E668 /* BoringExtrasMenu.swift in Sources */,
+				B15063542C63E18700EBB0E3 /* SettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -411,7 +427,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"boringNotch/Preview Content\"";
-				DEVELOPMENT_TEAM = JPWMG84CH8;
+				DEVELOPMENT_TEAM = 342QMGS27Q;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -446,7 +462,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"boringNotch/Preview Content\"";
-				DEVELOPMENT_TEAM = JPWMG84CH8;
+				DEVELOPMENT_TEAM = 342QMGS27Q;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -4,7 +4,7 @@ import Combine
 
 struct ContentView: View {
     let onHover: () -> Void
-    @StateObject var vm: BoringViewModel
+    @EnvironmentObject var vm: BoringViewModel
     @StateObject var batteryModel: BatteryStatusViewModel
     var body: some View {
         BoringNotch(vm: vm, onHover: onHover, batteryModel: batteryModel)

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -13,7 +13,8 @@ struct DynamicNotchApp: App {
     
     var body: some Scene {
         Settings {
-            EmptyView()
+            SettingsView()
+                .environmentObject(appDelegate.vm)
         }
     }
 }
@@ -22,6 +23,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem?
     var window: NSWindow!
     var sizing: Sizes = Sizes()
+    let vm: BoringViewModel = BoringViewModel()
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return false
@@ -56,7 +58,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             contentRect: NSRect(x: 0, y: 0, width: sizing.size.opened.width!, height: sizing.size.opened.height!), styleMask: [.borderless], backing: .buffered, defer: false
         )
         
-        window.contentView = NSHostingView(rootView: ContentView(onHover: adjustWindowPosition, vm: .init(), batteryModel: .init()))
+        window.contentView = NSHostingView(rootView: ContentView(onHover: adjustWindowPosition, batteryModel: .init()).environmentObject(vm))
         
         // Set the initial window position
         adjustWindowPosition()

--- a/boringNotch/components/BoringExtrasMenu.swift
+++ b/boringNotch/components/BoringExtrasMenu.swift
@@ -35,6 +35,7 @@ struct BoringExtrasMenu : View {
             HStack(spacing: 20)  {
                 github
                 donate
+                settings
                 close
                 clear
             }
@@ -62,6 +63,20 @@ struct BoringExtrasMenu : View {
         )
     }
     
+    var settings: some View {
+        SettingsLink(label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12.0).fill(.black).frame(width: 70, height: 70)
+                VStack(spacing: 8) {
+                    Image(systemName: "gear").resizable()
+                        .aspectRatio(contentMode: .fit).frame(width:20)
+                    Text("Settings").font(.body)
+                }
+            }
+        })
+        .buttonStyle(PlainButtonStyle()).shadow(color: .black.opacity(0.5), radius: 10)
+    }
+    
     var close: some View {
         BoringLargeButtons(
             action: {
@@ -69,8 +84,8 @@ struct BoringExtrasMenu : View {
                     vm.openMusic()
                 }
             },
-            icon: Image(systemName: "xmark"),
-            title: "Close"
+            icon: Image(systemName: "arrow.down.forward.and.arrow.up.backward"),
+            title: "Hide"
         )
     }
     
@@ -83,7 +98,7 @@ struct BoringExtrasMenu : View {
                     }
                 }
             },
-            icon: Image(systemName: "trash"),
+            icon: Image(systemName: "xmark"),
             title: "Exit"
         )
     }

--- a/boringNotch/components/BoringHeader.swift
+++ b/boringNotch/components/BoringHeader.swift
@@ -30,7 +30,7 @@ struct BoringHeader: View {
                 }
                 BoringBatteryView(
                     batteryPercentage: percentage,
-                    isPluggedIn: isCharging      )
+                    isPluggedIn: isCharging)
             }
             .animation(vm.animation?.delay(0.6), value: vm.notchState)
             .font(.system(.headline, design: .rounded))

--- a/boringNotch/components/BoringNotch.swift
+++ b/boringNotch/components/BoringNotch.swift
@@ -29,20 +29,22 @@ struct BoringNotch: View {
                     BoringHeader(vm: vm, percentage: batteryModel.batteryPercentage, isCharging: batteryModel.isPluggedIn).padding(.leading, 6).padding(.trailing, 10).animation(.spring(response: 0.7, dampingFraction: 0.8, blendDuration: 0.8), value: vm.notchState)
                 }
                 
-                HStack(spacing: 10) {
+                HStack(spacing: 15) {
                     if vm.notchState == .closed && batteryModel.showChargingInfo {
                         Text("Charging")
                     }
-                    if (musicManager.isPlaying  || musicManager.lastUpdated.timeIntervalSinceNow > -vm.waitInterval) && (!batteryModel.showChargingInfo || vm.notchState == .open) && vm.currentView != .menu  {
+                    if (musicManager.isPlaying || musicManager.lastUpdated.timeIntervalSinceNow > -vm.waitInterval) && (!batteryModel.showChargingInfo || vm.notchState == .open) && vm.currentView != .menu  {
                         
                         Image(nsImage: musicManager.albumArt)
                             .resizable()
-                            .aspectRatio(contentMode: .fill).frame(
+                            .aspectRatio(contentMode: .fill)
+                            .frame(
                                 width: vm.notchState == .open ? vm.musicPlayerSizes.image.size.opened.width : vm.musicPlayerSizes.image.size.closed.width,
                                 height: vm.notchState == .open ? vm.musicPlayerSizes.image.size.opened.height : vm.musicPlayerSizes.image.size.closed.height
                             )
                             .cornerRadius(vm.notchState == .open ? vm.musicPlayerSizes.image.corderRadius.opened.inset! : vm.musicPlayerSizes.image.corderRadius.closed.inset!)
                             .scaledToFit()
+                            .padding(.leading, vm.notchState == .open ? 5 : 0)
                         // Fit the image within the frame
                     }
                     
@@ -99,25 +101,21 @@ struct BoringNotch: View {
                     }
                     
                     
-                    if musicManager.isPlaying == false && vm.notchState == .closed && !batteryModel.showChargingInfo {
-                        
-                        MinimalFaceFeatures().transition(.blurReplace.animation(.spring(.bouncy(duration: 0.3))))
-                    }
-                    
                     if vm.notchState == .closed && batteryModel.showChargingInfo {
                         BoringBatteryView(batteryPercentage: batteryModel.batteryPercentage, isPluggedIn: batteryModel.isPluggedIn)
                     }
                     
-                    if musicManager.isPlaying && !batteryModel.showChargingInfo && vm.currentView != .menu {
+                    if !batteryModel.showChargingInfo && vm.currentView != .menu {
                         
-                        MusicVisualizer()
+                        MusicVisualizer(avgColor: musicManager.albumArt.averageColor(), isPlaying: musicManager.isPlaying)
                             .frame(width: 30).padding(.horizontal, vm.notchState == .open ? 8 : 2)
                         
                     }
                 }
             }.frame(width: vm.notchState == .open ? 430 : batteryModel.showChargingInfo ? CGFloat(270) + CGFloat(100): 285)
                 .padding(.horizontal, 10).padding(.vertical, vm.notchState == .open ? 10: 20).padding(.bottom, vm.notchState == .open ?5:0).transition(.blurReplace.animation(.spring(.bouncy(duration: 0.5))))
-        }.onHover { hovering in
+        }
+        .onHover { hovering in
             withAnimation(vm.animation) {
                 if hovering {
                     vm.open()
@@ -127,7 +125,8 @@ struct BoringNotch: View {
                 }
                 self.onHover()
             }
-        }.onChange(of: batteryModel.isPluggedIn, { oldValue, newValue in
+        }
+        .onChange(of: batteryModel.isPluggedIn, { oldValue, newValue in
             withAnimation(.spring(response: 1, dampingFraction: 0.8, blendDuration: 0.7)) {
                 if newValue {
                     batteryModel.showChargingInfo = true
@@ -136,7 +135,7 @@ struct BoringNotch: View {
                 }
             }
         })
-        
+        .environmentObject(vm)
     }
 }
 

--- a/boringNotch/components/BoringNotchWindow.swift
+++ b/boringNotch/components/BoringNotchWindow.swift
@@ -34,7 +34,7 @@ class BoringNotchWindow: NSWindow {
             .ignoresCycle,
         ]
         isReleasedWhenClosed = false
-        level = .statusBar
+        level = .mainMenu + 1
         hasShadow = true
     }
     

--- a/boringNotch/components/MusicVisualizer.swift
+++ b/boringNotch/components/MusicVisualizer.swift
@@ -9,21 +9,24 @@ import SwiftUI
 
 struct MusicVisualizer: View {
     @State private var amplitudes: [CGFloat] = Array(repeating: 0, count: 5)
+    @EnvironmentObject var vm: BoringViewModel
+    let avgColor: NSColor?
+    let isPlaying: Bool
     let timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
     
     var body: some View {
-        HStack(spacing: 2) {
-            ForEach(0..<5) { index in
+        HStack(spacing: 3) {
+            ForEach(0..<4) { index in
                 Capsule()
-                    .fill(Color.white)
-                    .frame(width: 3, height: amplitudes[index])
+                    .fill(vm.coloredSpectrogram ? Color(nsColor: avgColor ?? .white) : .white)
+                    .frame(width: 1.5, height: isPlaying ? amplitudes[index] : 2)
             }
         }
         .transition(.scale.animation(.spring(.bouncy(duration: 0.6))))
         .onReceive(timer) { _ in
             withAnimation(.spring(.bouncy(duration: 0.6))) {
                 for i in 0..<5 {
-                    amplitudes[i] = CGFloat.random(in: 5...20)
+                    amplitudes[i] = CGFloat.random(in: 3...12)
                 }
             }
         }

--- a/boringNotch/components/SettingsView.swift
+++ b/boringNotch/components/SettingsView.swift
@@ -7,9 +7,31 @@
 
 import SwiftUI
 
+enum settingsEnum {
+    case general
+}
+
 struct SettingsView: View {
+    @EnvironmentObject var vm: BoringViewModel
+    @State private var selectedTab: settingsEnum = .general
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        TabView(selection: $selectedTab,
+                content:  {
+            GeneralSettings().tabItem { Label("General", systemImage: "gear") }.tag(settingsEnum.general)
+        })
+    }
+    
+    @ViewBuilder
+    func GeneralSettings() -> some View {
+        Form {
+            Section {
+                Toggle("Enable colored spectrograms", isOn: $vm.coloredSpectrogram.animation())
+                TextField("Media inactivity timeout", value: $vm.waitInterval, formatter: NumberFormatter())
+            } header: {
+                Text("Media playback live activity")
+            }
+        }
+        .formStyle(.grouped)
     }
 }
 

--- a/boringNotch/components/SettingsView.swift
+++ b/boringNotch/components/SettingsView.swift
@@ -1,0 +1,18 @@
+//
+//  SettingsView.swift
+//  boringNotch
+//
+//  Created by Richard Kunkli on 07/08/2024.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/boringNotch/extensions/Image2Color.swift
+++ b/boringNotch/extensions/Image2Color.swift
@@ -1,0 +1,18 @@
+//
+//  Image2Color.swift
+//  boringNotch
+//
+//  Created by Richard Kunkli on 07/08/2024.
+//
+
+import SwiftUI
+
+struct Image2Color: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    Image2Color()
+}

--- a/boringNotch/extensions/Image2Color.swift
+++ b/boringNotch/extensions/Image2Color.swift
@@ -6,13 +6,77 @@
 //
 
 import SwiftUI
+import AppKit
 
-struct Image2Color: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+extension NSImage {
+    func averageColor() -> NSColor? {
+        guard let cgImage = self.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+        
+        let width = cgImage.width
+        let height = cgImage.height
+        let totalPixels = width * height
+        
+        guard let context = CGContext(data: nil,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: width * 4,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else {
+            return nil
+        }
+        
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        
+        guard let data = context.data else {
+            return nil
+        }
+        
+        let pointer = data.bindMemory(to: UInt32.self, capacity: totalPixels)
+        
+        var totalRed = 0
+        var totalGreen = 0
+        var totalBlue = 0
+        
+        for i in 0..<totalPixels {
+            let color = pointer[i]
+            totalRed += Int(color & 0xFF)
+            totalGreen += Int((color >> 8) & 0xFF)
+            totalBlue += Int((color >> 16) & 0xFF)
+        }
+        
+        let averageRed = CGFloat(totalRed) / CGFloat(totalPixels) / 255.0
+        let averageGreen = CGFloat(totalGreen) / CGFloat(totalPixels) / 255.0
+        let averageBlue = CGFloat(totalBlue) / CGFloat(totalPixels) / 255.0
+        
+        let minBrightness: CGFloat = 0.5
+        let isNearBlack = averageRed < 0.03 && averageGreen < 0.03 && averageBlue < 0.03
+        
+        if isNearBlack {
+            // If it's near black, just return a gray color with the minimum brightness
+            return NSColor(white: minBrightness, alpha: 1.0)
+        } else {
+            var color = NSColor(red: averageRed, green: averageGreen, blue: averageBlue, alpha: 1.0)
+            
+            var hue: CGFloat = 0
+            var saturation: CGFloat = 0
+            var brightness: CGFloat = 0
+            var alpha: CGFloat = 0
+            
+            color.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+            
+            if brightness < minBrightness {
+                // Increase brightness while maintaining hue and reducing saturation
+                let saturationScale = brightness / minBrightness
+                color = NSColor(hue: hue,
+                                saturation: saturation * saturationScale,
+                                brightness: minBrightness,
+                                alpha: alpha)
+            }
+            
+            return color
+        }
     }
-}
-
-#Preview {
-    Image2Color()
 }

--- a/boringNotch/managers/MusicManager.swift
+++ b/boringNotch/managers/MusicManager.swift
@@ -59,7 +59,12 @@ class MusicManager: ObservableObject {
         
         // Get song info
         MRMediaRemoteGetNowPlayingInfo(DispatchQueue.main) { [weak self] information in
-            guard let self = self else { self?.isPlaying = false; return }
+            guard let self = self else {
+                withAnimation {
+                    self?.isPlaying = false
+                }
+                return
+            }
             
             // check if the song is paused
             if let state = information["kMRMediaRemoteNowPlayingInfoPlaybackRate"] as? Int {
@@ -74,8 +79,10 @@ class MusicManager: ObservableObject {
                     self.lastUpdated = Date()
                 }
                 
-                self.isPlaying = state == 1
-                playbackManager.isPlaying = state == 1
+                withAnimation {
+                    self.isPlaying = state == 1
+                    self.playbackManager.isPlaying = state == 1
+                }
                 
             }
             
@@ -121,7 +128,10 @@ class MusicManager: ObservableObject {
     func togglePlayPause() {
         // Implement play/pause functionality
         playbackManager.playPause()
-        isPlaying = playbackManager.isPlaying
+        
+        withAnimation {
+            isPlaying = playbackManager.isPlaying
+        }
         
         if isPlaying {
             fetchNowPlayingInfo()

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -21,7 +21,8 @@ class BoringViewModel: NSObject, ObservableObject {
     @Published var sizes : Sizes = Sizes()
     @Published var musicPlayerSizes: MusicPlayerElementSizes = MusicPlayerElementSizes()
     @Published var waitInterval: Double = 10
-    @Published var releaseName:String = "Beautiful Sheep"
+    @Published var releaseName: String = "Beautiful Sheep"
+    @Published var coloredSpectrogram: Bool = true
     
     deinit {
         destroy()


### PR DESCRIPTION
# Fixes
- Refactor BoringViewModel observed object to initialize in the appdelegate. It is important because the new settings changes variables of the env object and it has to be in the same instance
- Changed icon in the HeaderExtras, because it was confusing
# New features
- Implemented a new extension that extract the average color from the album art, and it is used in the audio spectrogram, which has been optimized and resized
- New settings window with some options, giving users ability to customize their experience
# Preview
<img width="582" alt="Screenshot 2024-08-07 at 20 41 51" src="https://github.com/user-attachments/assets/eaa7f6cc-d831-40d6-a8db-1557d0e9240c">