### PR TITLE
Conditionally Display Battery Tab in Settings Based on Device Battery and Charging Status

### DIFF
--- a/boringNotch/components/SettingsView.swift
+++ b/boringNotch/components/SettingsView.swift
@@ -18,34 +18,39 @@ struct SettingsView: View {
     let accentColors: [Color] = [.blue, .purple, .pink, .red, .orange, .yellow, .green, .gray]
     
     var body: some View {
-        TabView(selection: $selectedTab,
-                content:  {
+        TabView(selection: $selectedTab) {
             GeneralSettings()
                 .tabItem { Label("General", systemImage: "gear") }
                 .tag(SettingsEnum.general)
             Media()
                 .tabItem { Label("Media", systemImage: "music.note") }
                 .tag(SettingsEnum.mediaPlayback)
-            Charge()
-                .tabItem { Label("Battery", systemImage: "battery.100.bolt") }
-                .tag(SettingsEnum.charge)
+            if shouldShowBatteryTab() {
+                Charge()
+                    .tabItem { Label("Battery", systemImage: "battery.100.bolt") }
+                    .tag(SettingsEnum.charge)
+            }
             Downloads()
                 .tabItem { Label("Downloads", systemImage: "square.and.arrow.down") }
                 .tag(SettingsEnum.download)
             About()
                 .tabItem { Label("About", systemImage: "info.circle") }
                 .tag(SettingsEnum.about)
-        })
+        }
         .formStyle(.grouped)
         .frame(width: 600, height: 500)
         .tint(vm.accentColor)
+    }
+    
+    private func shouldShowBatteryTab() -> Bool {
+        return vm.showBattery && vm.chargingInfoAllowed && (vm.hasBattery || vm.isPluggedIn)
     }
     
     @ViewBuilder
     func GeneralSettings() -> some View {
         Form {
             Section {
-                HStack() {
+                HStack {
                     ForEach(accentColors, id: \.self) { color in
                         Button(action: {
                             withAnimation {
@@ -178,7 +183,8 @@ struct SettingsView: View {
                 Text("Media playback live activity")
             }
         }
-        .formStyle(.grouped)}
+        .formStyle(.grouped)
+    }
     
     @ViewBuilder
     func boringControls() -> some View {
@@ -227,7 +233,7 @@ struct SettingsView: View {
                             Text("(\(Bundle.main.buildVersionNumber ?? ""))")
                                 .foregroundStyle(.secondary)
                         }
-                        Text(Bundle.main.releaseVersionNumber ?? "unkown")
+                        Text(Bundle.main.releaseVersionNumber ?? "unknown")
                             .foregroundStyle(.secondary)
                             .onTapGesture {
                                 withAnimation {


### PR DESCRIPTION
## Problem:
The "Battery" tab in the SettingsView is displayed on all devices, including those without a battery (e.g., Mac Studio) or when the device is not plugged in. This leads to confusion and clutter in the user interface for devices where battery-related settings are irrelevant.

## Solution:
Introduced logic to conditionally display the "Battery" tab in the SettingsView only when the device has a battery or is plugged in. This was achieved by implementing checks in the BoringViewModel using IOKit to detect battery presence and charging status.

## Changes:
* Added Battery and Charging Checks:
> * Implemented `checkForBattery()` and `checkIfPluggedIn()` methods in **BoringViewModel** to determine the device's battery and charging status.
> * Introduced new `@Published` properties `hasBattery` and `isPluggedIn` in `BoringViewModel` to store these statuses.

* Conditional Display of Battery Tab:
> * Updated `SettingsView` to include a `shouldShowBatteryTab()` method that determines whether the "Battery" tab should be displayed based on the new `BoringViewModel` properties.
> * The "Battery" tab is now only shown when hasBattery is true or isPluggedIn is true.
## Testing:

* Manually tested on a device with a battery to ensure the "Battery" tab is displayed correctly.
* Verified that on devices without a battery or when not plugged in, the "Battery" tab is not displayed.
* Checked that other settings and functionalities continue to work as expected, ensuring that the UI adapts correctly to different device states.

## Checklist:

* Implemented battery and charging status checks in `BoringViewModel`.
* Updated `SettingsView` to conditionally display the "Battery" tab.
* Manually tested on multiple devices to confirm the correct behavior of the battery tab.

## Related Issues:
This change improves the user interface by ensuring that only relevant settings are displayed based on the device's hardware, reducing potential confusion and improving the overall user experience.

Please do check on your side as well.
With kind regards,
Saba.