### PR TITLE
Suggestion: Hide album cover when closed and idle

### DIFF
--- a/boringNotch/components/NotchContentView.swift
+++ b/boringNotch/components/NotchContentView.swift
@@ -31,7 +31,7 @@ struct NotchContentView: View {
                     if vm.notchState == .closed && batteryModel.showChargingInfo {
                         Text("Charging").foregroundStyle(.white).padding(.leading, 4)
                     }
-                    if !batteryModel.showChargingInfo && vm.currentView != .menu  {
+                    if !batteryModel.showChargingInfo && vm.currentView != .menu && !(vm.notchState == .closed && musicManager.isPlayerIdle)  {
                         
                         Image(nsImage: musicManager.albumArt)
                             .resizable()


### PR DESCRIPTION
~~Hi! 😃 I just wanted to hide the album cover when Notch is closed and no music is playing to free up space on the status bar. Please share your thoughts! We can also make this behavior configurable if you'd like. Let me know!~~

Strange... It doesn't seem to be reproducible and already works as I described, sorry to bother you, I'm closing the Pull Request