### PR TITLE
Fix: Fix battery percentage text color

### DIFF
--- a/boringNotch/components/BoringBattery.swift
+++ b/boringNotch/components/BoringBattery.swift
@@ -55,5 +55,9 @@ struct BoringBatteryView: View {
 }
 
 #Preview {
-    BatteryView(percentage: 100, isCharging: true, batteryWidth: 30).frame(width: 200, height: 200)
+    BoringBatteryView(
+        batteryPercentage: 40,
+        isPluggedIn: true,
+        batteryWidth: 30
+    ).frame(width: 200, height: 200)
 }

--- a/boringNotch/components/BoringHeader.swift
+++ b/boringNotch/components/BoringHeader.swift
@@ -16,7 +16,6 @@ struct BoringHeader: View {
             Text(vm.headerTitle)
                 .contentTransition(.numericText())
                 .font(.system(size: 12, design: .rounded))
-                .foregroundStyle(.gray)
             Spacer()
             HStack(spacing: 4){
                 if(vm.settingsIconInNotch) {
@@ -42,7 +41,7 @@ struct BoringHeader: View {
             }
             .animation(vm.animation?.delay(0.6), value: vm.notchState)
             .font(.system(.headline, design: .rounded))
-        }
+        }.foregroundColor(.gray)
     }}
 
 #Preview {


### PR DESCRIPTION
Fix for the battery percentage text foreground color

Before:
<img width="533" alt="image" src="https://github.com/user-attachments/assets/67af9174-fb1f-4f05-8915-8b343ff34d66">

After:
<img width="581" alt="image" src="https://github.com/user-attachments/assets/4406ac03-dbee-4266-a334-dcdc51a403fe">
